### PR TITLE
Fix docker action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,17 +36,19 @@ jobs:
         if: contains(github.event_name, 'push')
         uses: docker/build-push-action@v3
         with:
-          context: ./docker/
+          context: ./docker/avni/
           cache-to: type=inline
-          push: false
-          tags: globalseismology/avni:latest
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:latest
 
       - name: Build and push Docker image for release
         if: contains(github.event_name, 'release')
         uses: docker/build-push-action@v3
         with:
-          context: ./docker/
+          context: ./docker/avni/
           cache-to: type=inline
-          push: false
-          tags: globalseismology/avni:${{github.ref_name}}
+          push: true
+          tags: |
+            ${{ github.repository_owner }}/${{ github.repository }}:${{github.ref_name}}
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ else:
 #---------------------------------------------------------------------------
 
 f90_dir='avni/f2py'
-packagelist=['avni','avni.api','avni.data','avni.models','avni.tools',
+packagelist=['avni','avni.data','avni.models','avni.tools',
              'avni.mapping','avni.plots']
 for module in os.listdir(f90_dir): packagelist.append('avni.f2py.'+module)
 


### PR DESCRIPTION
This fixes the build of the docker action.
Changes:
- use correct context (directory that stores the dockerfile)
- activate pushing the build image to docker hub
- generalize the name of the image (this is not necessary, but makes it easier for me, I am reusing the same commands for a bunch of projects
- remove 'avni.api' from setup.py. Otherwise the installation process fails.